### PR TITLE
Add flatpickr init to turboloads

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -32,6 +32,6 @@ import { initFlatpickr } from "../plugins/flatpickr";
 document.addEventListener('turbolinks:load', () => {
   // Call your functions here, e.g:
   // initSelect2();
+  initFlatpickr();
 });
 
-initFlatpickr();


### PR DESCRIPTION
Flatpickr was only loading on page start, had to refresh to load styling. Moved the init in application.css to turboloads so that it automatically loads on each page.